### PR TITLE
RequestValidation handles CannotProcessRequest exceptions

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -310,16 +310,16 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v9.45.1",
+            "version": "v9.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "7a8afa0875d7de162f30865d9fae33c8fb235fa2"
+                "reference": "03777893d04776c2491c7b85fff3e4dd6723d928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/7a8afa0875d7de162f30865d9fae33c8fb235fa2",
-                "reference": "7a8afa0875d7de162f30865d9fae33c8fb235fa2",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/03777893d04776c2491c7b85fff3e4dd6723d928",
+                "reference": "03777893d04776c2491c7b85fff3e4dd6723d928",
                 "shasum": ""
             },
             "require": {
@@ -361,11 +361,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-12-02T18:48:05+00:00"
+            "time": "2022-12-24T19:41:01+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.45.1",
+            "version": "v9.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -411,16 +411,16 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.45.1",
+            "version": "v9.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "c7cc6e6198cac6dfdead111f9758de25413188b7"
+                "reference": "856ad15be8d80a2f217d30cfe2df3fc3a5c886fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/c7cc6e6198cac6dfdead111f9758de25413188b7",
-                "reference": "c7cc6e6198cac6dfdead111f9758de25413188b7",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/856ad15be8d80a2f217d30cfe2df3fc3a5c886fd",
+                "reference": "856ad15be8d80a2f217d30cfe2df3fc3a5c886fd",
                 "shasum": ""
             },
             "require": {
@@ -455,11 +455,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-10-31T22:25:40+00:00"
+            "time": "2022-12-31T20:34:28+00:00"
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v9.45.1",
+            "version": "v9.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -521,16 +521,16 @@
         },
         {
             "name": "illuminate/http",
-            "version": "v9.45.1",
+            "version": "v9.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",
-                "reference": "5a0284d6bff14a233c2280f0782be4b5bc6b03ab"
+                "reference": "2b5718dd35b5202cc6b934f7335d507957995c97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/http/zipball/5a0284d6bff14a233c2280f0782be4b5bc6b03ab",
-                "reference": "5a0284d6bff14a233c2280f0782be4b5bc6b03ab",
+                "url": "https://api.github.com/repos/illuminate/http/zipball/2b5718dd35b5202cc6b934f7335d507957995c97",
+                "reference": "2b5718dd35b5202cc6b934f7335d507957995c97",
                 "shasum": ""
             },
             "require": {
@@ -576,11 +576,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-12-16T16:52:48+00:00"
+            "time": "2022-12-30T02:09:01+00:00"
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.45.1",
+            "version": "v9.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -626,7 +626,7 @@
         },
         {
             "name": "illuminate/session",
-            "version": "v9.45.1",
+            "version": "v9.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/session.git",
@@ -682,16 +682,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v9.45.1",
+            "version": "v9.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "d7f7c07e35a2c09cbeeddc0168826cf05a2eeb84"
+                "reference": "d81ba4b42bb3a5aa80ef3bea5837db1ee8d5c166"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/d7f7c07e35a2c09cbeeddc0168826cf05a2eeb84",
-                "reference": "d7f7c07e35a2c09cbeeddc0168826cf05a2eeb84",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/d81ba4b42bb3a5aa80ef3bea5837db1ee8d5c166",
+                "reference": "d81ba4b42bb3a5aa80ef3bea5837db1ee8d5c166",
                 "shasum": ""
             },
             "require": {
@@ -748,7 +748,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-12-20T14:03:34+00:00"
+            "time": "2023-01-03T14:41:26+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -3338,16 +3338,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.9.5",
+            "version": "1.9.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "4d18c5d98965029c2aa1ccbd91dc22e7ba8c5034"
+                "reference": "0501435cd342eac7664bd62155b1ef907fc60b6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/4d18c5d98965029c2aa1ccbd91dc22e7ba8c5034",
-                "reference": "4d18c5d98965029c2aa1ccbd91dc22e7ba8c5034",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/0501435cd342eac7664bd62155b1ef907fc60b6f",
+                "reference": "0501435cd342eac7664bd62155b1ef907fc60b6f",
                 "shasum": ""
             },
             "require": {
@@ -3377,7 +3377,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.9.5"
+                "source": "https://github.com/phpstan/phpstan/tree/1.9.7"
             },
             "funding": [
                 {
@@ -3393,7 +3393,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-02T21:35:42+00:00"
+            "time": "2023-01-04T21:59:57+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/config/membrane.php
+++ b/config/membrane.php
@@ -24,5 +24,6 @@ return [
     */
     'validation_error_response_code' => 400,
     'validation_error_response_type' => 'about:blank',
+    'api_problem_response_types' => [],
 
 ];

--- a/src/ApiProblemBuilder.php
+++ b/src/ApiProblemBuilder.php
@@ -6,27 +6,59 @@ namespace Membrane\Laravel;
 
 use Crell\ApiProblem\ApiProblem;
 use Crell\ApiProblem\HttpConverter;
+use Membrane\OpenAPI\Exception\CannotProcessRequest;
 use Membrane\Renderer\Renderer;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class ApiProblemBuilder
 {
+    /** @param string[] $apiResponseTypes */
     public function __construct(
         private readonly int $errorCode,
-        private readonly string $errorType
+        private readonly string $errorType,
+        private readonly array $apiResponseTypes
     ) {
     }
 
+    /** @deprecated */
     public function build(Renderer $renderer): SymfonyResponse
+    {
+        trigger_error('Method ' . __METHOD__ . ' is deprecated', E_USER_DEPRECATED);
+
+        return $this->buildFromRenderer($renderer);
+    }
+
+    public function buildFromRenderer(Renderer $renderer): SymfonyResponse
     {
         $problem = (new ApiProblem('Request payload failed validation'))
             ->setStatus($this->errorCode)
             ->setType($this->errorType);
         $problem['errors'] = $renderer->jsonSerialize();
 
-        $converter = new HttpConverter(new Psr17Factory());
+        return $this->convertToResponse($problem);
+    }
 
+    public function buildFromException(CannotProcessRequest $exception): SymfonyResponse
+    {
+        $errorCode = match ($exception->getCode()) {
+            0 => 404,
+            1 => 405,
+            2 => 406,
+            default => $this->errorCode
+        };
+
+        $problem = (new ApiProblem(SymfonyResponse::$statusTexts[$errorCode]))
+            ->setStatus($errorCode)
+            ->setType($this->apiResponseTypes[$errorCode] ?? $this->errorType)
+            ->setDetail($exception->getMessage());
+
+        return $this->convertToResponse($problem);
+    }
+
+    private function convertToResponse(ApiProblem $problem): SymfonyResponse
+    {
+        $converter = new HttpConverter(new Psr17Factory());
 
         return (new ToSymfony())($converter->toJsonResponse($problem));
     }

--- a/src/Middleware/ResponseJsonFlat.php
+++ b/src/Middleware/ResponseJsonFlat.php
@@ -26,7 +26,7 @@ class ResponseJsonFlat
 
         assert($result instanceof Result);
         if (!$result->isValid()) {
-            return $this->apiProblemBuilder->build(new JsonFlat($result));
+            return $this->apiProblemBuilder->buildFromRenderer(new JsonFlat($result));
         }
 
         return $next($request);

--- a/src/Middleware/ResponseJsonNested.php
+++ b/src/Middleware/ResponseJsonNested.php
@@ -26,7 +26,7 @@ class ResponseJsonNested
 
         assert($result instanceof Result);
         if (!$result->isValid()) {
-            return $this->apiProblemBuilder->build(new JsonNested($result));
+            return $this->apiProblemBuilder->buildFromRenderer(new JsonNested($result));
         }
 
         return $next($request);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -31,5 +31,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->app->when(ApiProblemBuilder::class)
             ->needs('$errorType')
             ->giveConfig('membrane.validation_error_response_type');
+        $this->app->when(ApiProblemBuilder::class)
+            ->needs('$apiProblemTypes')
+            ->giveConfig('membrane.api_response_types');
     }
 }

--- a/tests/ApiProblemBuilderTest.php
+++ b/tests/ApiProblemBuilderTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Membrane\Laravel;
 
+use Membrane\OpenAPI\Exception\CannotProcessRequest;
 use Membrane\Renderer\Renderer;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 /**
  * @covers \Membrane\Laravel\ApiProblemBuilder
@@ -15,7 +17,7 @@ class ApiProblemBuilderTest extends TestCase
 {
 
     /** @test */
-    public function buildsApiProblemImplementingServerResponseInterface(): void
+    public function buildFromRendererTest(): void
     {
         $expected = [
             'errors' => [
@@ -27,15 +29,85 @@ class ApiProblemBuilderTest extends TestCase
 
         ];
 
-        $sut = new ApiProblemBuilder(400, 'about:blank');
+        $sut = new ApiProblemBuilder(400, 'about:blank', []);
         $renderer = self::createMock(Renderer::class);
         $renderer->expects(self::once())
             ->method('jsonSerialize')
             ->willReturn(['id' => ['must be an integer']]);
 
-        $actual = $sut->build($renderer);
+        $actual = $sut->buildFromRenderer($renderer);
 
         self::assertEquals($expected, json_decode($actual->getContent(), true));
+    }
+
+    public function dataSetsToBuildFromException(): array
+    {
+        return [
+            'path not found, no apiResponseTypes' => [
+                CannotProcessRequest::pathNotFound('api.json', '/pets'),
+                new SymfonyResponse(
+                    '{"title":"Not Found","type":"about:blank","status":404,"detail":"\/pets does not match any specified paths in api.json"}',
+                    404,
+                    ['Content-Type' => 'application/problem+json']
+                ),
+                [],
+            ],
+            'path not found, no applicable apiResponseType' => [
+                CannotProcessRequest::pathNotFound('api.json', '/pets'),
+                new SymfonyResponse(
+                    '{"title":"Not Found","type":"about:blank","status":404,"detail":"\/pets does not match any specified paths in api.json"}',
+                    404,
+                    ['Content-Type' => 'application/problem+json']
+                ),
+                [418 => 'I\'m a teapot'],
+            ],
+            'path not found, applicable apiResponseType' => [
+                CannotProcessRequest::pathNotFound('api.json', '/pets'),
+                new SymfonyResponse(
+                    '{"title":"Not Found","type":"Path Not Found","status":404,"detail":"\/pets does not match any specified paths in api.json"}',
+                    404,
+                    ['Content-Type' => 'application/problem+json']
+                ),
+                [404 => 'Path Not Found', 418 => 'I\'m a teapot'],
+            ],
+            'method not found, applicable apiResponseType' => [
+                CannotProcessRequest::methodNotFound('get'),
+                new SymfonyResponse(
+                    '{"title":"Method Not Allowed","type":"Method Not Found","status":405,"detail":"get operation not specified on path"}',
+                    405,
+                    ['Content-Type' => 'application/problem+json']
+                ),
+                [404 => 'Path Not Found', 405 => 'Method Not Found', 418 => 'I\'m a teapot'],
+            ],
+            'content type not supported, applicable apiResponseType' => [
+                CannotProcessRequest::unsupportedContent(),
+                new SymfonyResponse(
+                    '{"title":"Not Acceptable","type":"Not Accepted","status":406,"detail":"APISpec expects application\/json content"}',
+                    406,
+                    ['Content-Type' => 'application/problem+json']
+                ),
+                [404 => 'Path Not Found', 405 => 'Method Not Found', 406 => 'Not Accepted', 418 => 'I\'m a teapot'],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToBuildFromException
+     */
+    public function buildFromExceptionTest(
+        CannotProcessRequest $exception,
+        SymfonyResponse $expected,
+        array $apiResponseTypes
+    ): void {
+        $expected->setProtocolVersion('1.1');
+        $sut = new ApiProblemBuilder(400, 'about:blank', $apiResponseTypes);
+
+        $actual = $sut->buildFromException($exception);
+
+        self::assertSame($expected->getContent(), $actual->getContent());
+        self::assertSame($expected->getStatusCode(), $actual->getStatusCode());
+        self::assertSame($expected->headers->get('Content-Type'), $actual->headers->get('Content-Type'));
     }
 
 }

--- a/tests/Middleware/ResponseJsonFlatTest.php
+++ b/tests/Middleware/ResponseJsonFlatTest.php
@@ -51,7 +51,7 @@ class ResponseJsonFlatTest extends TestCase
     {
         $request = self::createStub(Request::class);
         $container = self::createMock(Container::class);
-        $apiProblemBuilder = new ApiProblemBuilder(400, 'about:blank');
+        $apiProblemBuilder = new ApiProblemBuilder(400, 'about:blank', []);
         $sut = new ResponseJsonFlat($container, $apiProblemBuilder);
 
         $container->expects(self::once())

--- a/tests/Middleware/ResponseJsonNestedTest.php
+++ b/tests/Middleware/ResponseJsonNestedTest.php
@@ -51,7 +51,7 @@ class ResponseJsonNestedTest extends TestCase
     {
         $request = self::createStub(Request::class);
         $container = self::createMock(Container::class);
-        $apiProblemBuilder = new ApiProblemBuilder(400, 'about:blank');
+        $apiProblemBuilder = new ApiProblemBuilder(400, 'about:blank', []);
         $sut = new ResponseJsonNested($container, $apiProblemBuilder);
 
         $container->expects(self::once())


### PR DESCRIPTION
`ApiProblemBuilder->build` functionality moved to `ApiProblemBuilder->buildFromRenderer`

`ApiProblemBuilder->build` is marked as deprecated but returns `ApiProblemBuilder->buildFromRenderer` to avoid breaking backwards compatibility.

`ApiProblemBuilder->buildFromException` returns a Response from a `\Membrane\OpenAPI\Exceptions\CannotProcessRequest`  class
