### PR TITLE
Fix incorrectly named config option

### DIFF
--- a/src/ApiProblemBuilder.php
+++ b/src/ApiProblemBuilder.php
@@ -13,11 +13,11 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class ApiProblemBuilder
 {
-    /** @param string[] $apiResponseTypes */
+    /** @param string[] $apiProblemTypes */
     public function __construct(
         private readonly int $errorCode,
         private readonly string $errorType,
-        private readonly array $apiResponseTypes
+        private readonly array $apiProblemTypes
     ) {
     }
 
@@ -50,7 +50,7 @@ class ApiProblemBuilder
 
         $problem = (new ApiProblem(SymfonyResponse::$statusTexts[$errorCode]))
             ->setStatus($errorCode)
-            ->setType($this->apiResponseTypes[$errorCode] ?? $this->errorType)
+            ->setType($this->apiProblemTypes[$errorCode] ?? $this->errorType)
             ->setDetail($exception->getMessage());
 
         return $this->convertToResponse($problem);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -33,6 +33,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             ->giveConfig('membrane.validation_error_response_type');
         $this->app->when(ApiProblemBuilder::class)
             ->needs('$apiProblemTypes')
-            ->giveConfig('membrane.api_response_types');
+            ->giveConfig('membrane.api_problem_response_types');
     }
 }


### PR DESCRIPTION
Fixes several incorrectly named variables.

The config has api_problem_response_types:
https://github.com/membrane-php/membrane-laravel/blob/c3c87c7b549f0dced09ed3d37f7205c7496059f6/config/membrane.php#L27

The service provider was looking for  api_response_types and trying to provide it to $apiProblemTypes:
https://github.com/membrane-php/membrane-laravel/blob/c3c87c7b549f0dced09ed3d37f7205c7496059f6/src/ServiceProvider.php#L34-L36

But the ApiProblemBuilder has $apiResponseTypes!
https://github.com/membrane-php/membrane-laravel/blob/c3c87c7b549f0dced09ed3d37f7205c7496059f6/src/ApiProblemBuilder.php#L20

This PR fixes the inconsistencies.