### PR TITLE
laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
   "require": {
     "php": "^8.1.0",
     "crell/api-problem": "^3.6.1",
-    "illuminate/http": "^9.0",
-    "illuminate/support": "^9.0",
+    "illuminate/http": "^9.0 || ^10.0",
+    "illuminate/support": "^9.0 || ^10.0",
     "nyholm/psr7": "^1.5",
-    "membrane/membrane": "^0.2.0",
+    "membrane/membrane": "^0.3.0",
     "symfony/psr-http-message-bridge": "^2.1"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "symfony/psr-http-message-bridge": "^2.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5.27",
+    "phpunit/phpunit": "^10.0",
     "phpstan/phpstan": "^1.8",
     "squizlabs/php_codesniffer": "^3.7"
   },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,27 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         cacheResultFile=".phpunit.cache/test-results"
-         executionOrder="depends,defects"
-         forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         convertDeprecationsToExceptions="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true" beStrictAboutCoverageMetadata="true">
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true" beStrictAboutCoverageMetadata="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true" beStrictAboutCoverageMetadata="true">
   <testsuites>
     <testsuite name="default">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <coverage>
+  <coverage/>
+  <source>
     <include>
       <directory suffix=".php">src</directory>
     </include>
-  </coverage>
+  </source>
 </phpunit>

--- a/tests/ApiProblemBuilderTest.php
+++ b/tests/ApiProblemBuilderTest.php
@@ -6,17 +6,19 @@ namespace Membrane\Laravel;
 
 use Membrane\OpenAPI\Exception\CannotProcessRequest;
 use Membrane\Renderer\Renderer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
-/**
- * @covers \Membrane\Laravel\ApiProblemBuilder
- * @uses   \Membrane\Laravel\ToSymfony
- */
+#[CoversClass(ApiProblemBuilder::class)]
+#[UsesClass(ToSymfony::class)]
 class ApiProblemBuilderTest extends TestCase
 {
 
-    /** @test */
+    #[Test]
     public function buildFromRendererTest(): void
     {
         $expected = [
@@ -40,7 +42,7 @@ class ApiProblemBuilderTest extends TestCase
         self::assertEquals($expected, json_decode($actual->getContent(), true));
     }
 
-    public function dataSetsToBuildFromException(): array
+    public static function dataSetsToBuildFromException(): array
     {
         return [
             'path not found, no apiResponseTypes' => [
@@ -90,11 +92,9 @@ class ApiProblemBuilderTest extends TestCase
             ],
         ];
     }
-
-    /**
-     * @test
-     * @dataProvider dataSetsToBuildFromException
-     */
+    
+    #[Test]
+    #[DataProvider('dataSetsToBuildFromException')]
     public function buildFromExceptionTest(
         CannotProcessRequest $exception,
         SymfonyResponse $expected,

--- a/tests/Middleware/RequestValidationTest.php
+++ b/tests/Middleware/RequestValidationTest.php
@@ -8,20 +8,25 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Membrane\Laravel\ApiProblemBuilder;
+use Membrane\Laravel\ToPsr7;
+use Membrane\Laravel\ToSymfony;
 use Membrane\OpenAPI\Exception\CannotProcessRequest;
 use Membrane\OpenAPI\Method;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Laravel\Middleware\RequestValidation
- * @uses   \Membrane\Laravel\ApiProblemBuilder
- * @uses   \Membrane\Laravel\ToPsr7
- * @uses   \Membrane\Laravel\ToSymfony
- */
+
+#[CoversClass(RequestValidation::class)]
+#[UsesClass(ApiProblemBuilder::class)]
+#[UsesClass(ToPsr7::class)]
+#[UsesClass(ToSymfony::class)]
 class RequestValidationTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function registersResultInstanceInContainer(): void
     {
         $url = '/pets?limit=5&tags[]=cat&tags[]=tabby';
@@ -44,7 +49,7 @@ class RequestValidationTest extends TestCase
         $sut->handle(Request::create($url), fn($var) => new Response());
     }
 
-    public function dataSetsThatThrowCannotProcessRequest(): array
+    public static function dataSetsThatThrowCannotProcessRequest(): array
     {
         return [
             'path not found' => [
@@ -62,10 +67,8 @@ class RequestValidationTest extends TestCase
     }
 
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatThrowCannotProcessRequest
-     */
+    #[Test]
+    #[DataProvider('dataSetsThatThrowCannotProcessRequest')]
     public function catchesCannotProcessRequest(string $path, Method $method, CannotProcessRequest $expected): void
     {
         $apiProblemBuilder = self::createMock(ApiProblemBuilder::class);

--- a/tests/Middleware/ResponseJsonFlatTest.php
+++ b/tests/Middleware/ResponseJsonFlatTest.php
@@ -7,21 +7,25 @@ namespace Membrane\Laravel\Middleware;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Http\Request;
 use Membrane\Laravel\ApiProblemBuilder;
+use Membrane\Laravel\ToSymfony;
 use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
-/**
- * @covers \Membrane\Laravel\Middleware\ResponseJsonFlat
- * @uses   \Membrane\Laravel\ApiProblemBuilder
- * @uses   \Membrane\Laravel\ToSymfony
- */
+
+#[CoversClass(ResponseJsonFlat::class)]
+#[UsesClass(ApiProblemBuilder::class)]
+#[UsesClass(ToSymfony::class)]
 class ResponseJsonFlatTest extends TestCase
 {
-    public function dataSetsToHandle(): array
+    public static function dataSetsToHandle(): array
     {
         return [
             'valid results return valid responses' => [
@@ -43,10 +47,8 @@ class ResponseJsonFlatTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToHandle
-     */
+    #[Test]
+    #[DataProvider('dataSetsToHandle')]
     public function handleTest(Result $result, SymfonyResponse $expected): void
     {
         $request = self::createStub(Request::class);

--- a/tests/Middleware/ResponseJsonNestedTest.php
+++ b/tests/Middleware/ResponseJsonNestedTest.php
@@ -11,17 +11,20 @@ use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
-/**
- * @covers \Membrane\Laravel\Middleware\ResponseJsonNested
- * @uses   \Membrane\Laravel\ApiProblemBuilder
- * @uses   \Membrane\Laravel\ToSymfony
- */
+
+#[CoversClass('\Membrane\Laravel\Middleware\ResponseJsonNested')]
+#[UsesClass('  \Membrane\Laravel\ApiProblemBuilder')]
+#[UsesClass('  \Membrane\Laravel\ToSymfony')]
 class ResponseJsonNestedTest extends TestCase
 {
-    public function dataSetsToHandle(): array
+    public static function dataSetsToHandle(): array
     {
         return [
             'valid results return valid responses' => [
@@ -43,10 +46,8 @@ class ResponseJsonNestedTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToHandle
-     */
+    #[Test]
+    #[DataProvider('dataSetsToHandle')]
     public function handleTest(Result $result, SymfonyResponse $expected): void
     {
         $request = self::createStub(Request::class);


### PR DESCRIPTION
- Update PHPUnit to ^10.0
- Migrate PHPUnit configuration
- Fix PHPUnit deprecations
- Update test annotations to attributes
- upgrade to laravel v10 and membrane v0.3
