### PR TITLE
Update nyholm/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "crell/api-problem": "^3.6.1",
     "illuminate/http": "^9.0",
     "illuminate/support": "^9.0",
-    "nyholm/psr7": "^1.5",
+    "nyholm/psr7": "^1.8",
     "membrane/membrane": "^0.2.0",
     "symfony/psr-http-message-bridge": "^2.1"
   },


### PR DESCRIPTION
Vulnerability was found on versions < 1.6

Updating dependency to require version ^1.8