### PR TITLE
Update Membrane to 0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "illuminate/http": "^9.0 || ^10.0",
     "illuminate/support": "^9.0 || ^10.0",
     "nyholm/psr7": "^1.8",
-    "membrane/membrane": "^0.3.0",
+    "membrane/membrane": "^0.6.0",
     "symfony/psr-http-message-bridge": "^2.1"
   },
   "require-dev": {
@@ -27,6 +27,11 @@
       "providers": [
         "Membrane\\Laravel\\ServiceProvider"
       ]
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "infection/extension-installer": true
     }
   }
 }

--- a/src/ApiProblemBuilder.php
+++ b/src/ApiProblemBuilder.php
@@ -6,7 +6,6 @@ namespace Membrane\Laravel;
 
 use Crell\ApiProblem\ApiProblem;
 use Crell\ApiProblem\HttpConverter;
-use Membrane\OpenAPI\Exception\CannotProcessRequest;
 use Membrane\OpenAPI\Exception\CannotProcessSpecification;
 use Membrane\Renderer\Renderer;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -45,7 +44,6 @@ class ApiProblemBuilder
         $errorCode = match ($exception->getCode()) {
             CannotProcessSpecification::PATH_NOT_FOUND => 404,
             CannotProcessSpecification::METHOD_NOT_FOUND => 405,
-//            2 => 406,
             default => $this->errorCode
         };
 

--- a/src/ApiProblemBuilder.php
+++ b/src/ApiProblemBuilder.php
@@ -7,6 +7,7 @@ namespace Membrane\Laravel;
 use Crell\ApiProblem\ApiProblem;
 use Crell\ApiProblem\HttpConverter;
 use Membrane\OpenAPI\Exception\CannotProcessRequest;
+use Membrane\OpenAPI\Exception\CannotProcessSpecification;
 use Membrane\Renderer\Renderer;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
@@ -39,12 +40,12 @@ class ApiProblemBuilder
         return $this->convertToResponse($problem);
     }
 
-    public function buildFromException(CannotProcessRequest $exception): SymfonyResponse
+    public function buildFromException(CannotProcessSpecification $exception): SymfonyResponse
     {
         $errorCode = match ($exception->getCode()) {
-            0 => 404,
-            1 => 405,
-            2 => 406,
+            CannotProcessSpecification::PATH_NOT_FOUND => 404,
+            CannotProcessSpecification::METHOD_NOT_FOUND => 405,
+//            2 => 406,
             default => $this->errorCode
         };
 

--- a/src/Middleware/RequestValidation.php
+++ b/src/Middleware/RequestValidation.php
@@ -11,6 +11,7 @@ use Membrane\Laravel\ApiProblemBuilder;
 use Membrane\Laravel\ToPsr7;
 use Membrane\Membrane;
 use Membrane\OpenAPI\Exception\CannotProcessRequest;
+use Membrane\OpenAPI\Exception\CannotProcessSpecification;
 use Membrane\OpenAPI\Specification\Request as MembraneRequestSpec;
 use Membrane\Result\Result;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
@@ -35,11 +36,10 @@ class RequestValidation
 
         try {
             $specification = MembraneRequestSpec::fromPsr7($this->apiSpecPath, $psr7Request);
-        } catch (CannotProcessRequest $e) {
+            $result = $this->membrane->process($psr7Request, $specification);
+        } catch (CannotProcessSpecification $e) {
             return $this->apiProblemBuilder->buildFromException($e);
         }
-
-        $result = $this->membrane->process($psr7Request, $specification);
 
         $this->container->instance(Result::class, $result);
 

--- a/tests/ApiProblemBuilderTest.php
+++ b/tests/ApiProblemBuilderTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Membrane\Laravel;
 
-use Membrane\OpenAPI\Exception\CannotProcessRequest;
+use Membrane\OpenAPI\Exception\CannotProcessSpecification;
 use Membrane\Renderer\Renderer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -46,7 +46,7 @@ class ApiProblemBuilderTest extends TestCase
     {
         return [
             'path not found, no apiResponseTypes' => [
-                CannotProcessRequest::pathNotFound('api.json', '/pets'),
+                CannotProcessSpecification::pathNotFound('api.json', '/pets'),
                 new SymfonyResponse(
                     '{"title":"Not Found","type":"about:blank","status":404,"detail":"\/pets does not match any specified paths in api.json"}',
                     404,
@@ -55,7 +55,7 @@ class ApiProblemBuilderTest extends TestCase
                 [],
             ],
             'path not found, no applicable apiResponseType' => [
-                CannotProcessRequest::pathNotFound('api.json', '/pets'),
+                CannotProcessSpecification::pathNotFound('api.json', '/pets'),
                 new SymfonyResponse(
                     '{"title":"Not Found","type":"about:blank","status":404,"detail":"\/pets does not match any specified paths in api.json"}',
                     404,
@@ -64,7 +64,7 @@ class ApiProblemBuilderTest extends TestCase
                 [418 => 'I\'m a teapot'],
             ],
             'path not found, applicable apiResponseType' => [
-                CannotProcessRequest::pathNotFound('api.json', '/pets'),
+                CannotProcessSpecification::pathNotFound('api.json', '/pets'),
                 new SymfonyResponse(
                     '{"title":"Not Found","type":"Path Not Found","status":404,"detail":"\/pets does not match any specified paths in api.json"}',
                     404,
@@ -73,7 +73,7 @@ class ApiProblemBuilderTest extends TestCase
                 [404 => 'Path Not Found', 418 => 'I\'m a teapot'],
             ],
             'method not found, applicable apiResponseType' => [
-                CannotProcessRequest::methodNotFound('get'),
+                CannotProcessSpecification::methodNotFound('get'),
                 new SymfonyResponse(
                     '{"title":"Method Not Allowed","type":"Method Not Found","status":405,"detail":"get operation not specified on path"}',
                     405,
@@ -81,22 +81,23 @@ class ApiProblemBuilderTest extends TestCase
                 ),
                 [404 => 'Path Not Found', 405 => 'Method Not Found', 418 => 'I\'m a teapot'],
             ],
-            'content type not supported, applicable apiResponseType' => [
-                CannotProcessRequest::unsupportedContent(),
-                new SymfonyResponse(
-                    '{"title":"Not Acceptable","type":"Not Accepted","status":406,"detail":"APISpec expects application\/json content"}',
-                    406,
-                    ['Content-Type' => 'application/problem+json']
-                ),
-                [404 => 'Path Not Found', 405 => 'Method Not Found', 406 => 'Not Accepted', 418 => 'I\'m a teapot'],
-            ],
+            //TODO where are content types checked for requests?
+//            'content type not supported, applicable apiResponseType' => [
+//                CannotProcessSpecification::unsupportedContent(),
+//                new SymfonyResponse(
+//                    '{"title":"Not Acceptable","type":"Not Accepted","status":406,"detail":"APISpec expects application\/json content"}',
+//                    406,
+//                    ['Content-Type' => 'application/problem+json']
+//                ),
+//                [404 => 'Path Not Found', 405 => 'Method Not Found', 406 => 'Not Accepted', 418 => 'I\'m a teapot'],
+//            ],
         ];
     }
-    
+
     #[Test]
     #[DataProvider('dataSetsToBuildFromException')]
     public function buildFromExceptionTest(
-        CannotProcessRequest $exception,
+        CannotProcessSpecification $exception,
         SymfonyResponse $expected,
         array $apiResponseTypes
     ): void {

--- a/tests/ApiProblemBuilderTest.php
+++ b/tests/ApiProblemBuilderTest.php
@@ -81,16 +81,6 @@ class ApiProblemBuilderTest extends TestCase
                 ),
                 [404 => 'Path Not Found', 405 => 'Method Not Found', 418 => 'I\'m a teapot'],
             ],
-            //TODO where are content types checked for requests?
-//            'content type not supported, applicable apiResponseType' => [
-//                CannotProcessSpecification::unsupportedContent(),
-//                new SymfonyResponse(
-//                    '{"title":"Not Acceptable","type":"Not Accepted","status":406,"detail":"APISpec expects application\/json content"}',
-//                    406,
-//                    ['Content-Type' => 'application/problem+json']
-//                ),
-//                [404 => 'Path Not Found', 405 => 'Method Not Found', 406 => 'Not Accepted', 418 => 'I\'m a teapot'],
-//            ],
         ];
     }
 

--- a/tests/Middleware/RequestValidationTest.php
+++ b/tests/Middleware/RequestValidationTest.php
@@ -64,7 +64,6 @@ class RequestValidationTest extends TestCase
                 Method::DELETE,
                 CannotProcessSpecification::methodNotFound(Method::DELETE->value),
             ],
-            // TODO test 406 from unsupported content-types once Membrane is reading content-types from requests
         ];
     }
 

--- a/tests/Middleware/RequestValidationTest.php
+++ b/tests/Middleware/RequestValidationTest.php
@@ -10,7 +10,7 @@ use Illuminate\Http\Response;
 use Membrane\Laravel\ApiProblemBuilder;
 use Membrane\Laravel\ToPsr7;
 use Membrane\Laravel\ToSymfony;
-use Membrane\OpenAPI\Exception\CannotProcessRequest;
+use Membrane\OpenAPI\Exception\CannotProcessSpecification;
 use Membrane\OpenAPI\Method;
 use Membrane\Result\Result;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -36,8 +36,10 @@ class RequestValidationTest extends TestCase
                 'header' => [],
                 'cookie' => [],
                 'body' => '',
+                'request' => ['method' => 'get', 'operationId' => 'findPets'],
             ]
         );
+
         $apiProblemBuilder = self::createStub(ApiProblemBuilder::class);
         $container = self::createMock(Container::class);
         $sut = new RequestValidation(__DIR__ . '/../fixtures/petstore-expanded.json', $apiProblemBuilder, $container);
@@ -49,18 +51,18 @@ class RequestValidationTest extends TestCase
         $sut->handle(Request::create($url), fn($var) => new Response());
     }
 
-    public static function dataSetsThatThrowCannotProcessRequest(): array
+    public static function dataSetsThatThrowCannotProcessSpecification(): array
     {
         return [
             'path not found' => [
                 '/hats',
                 Method::GET,
-                CannotProcessRequest::pathNotFound('petstore-expanded.json', '/hats'),
+                CannotProcessSpecification::pathNotFound('petstore-expanded.json', '/hats'),
             ],
             'method not found' => [
                 '/pets',
                 Method::DELETE,
-                CannotProcessRequest::methodNotFound(Method::DELETE->value),
+                CannotProcessSpecification::methodNotFound(Method::DELETE->value),
             ],
             // TODO test 406 from unsupported content-types once Membrane is reading content-types from requests
         ];
@@ -68,9 +70,12 @@ class RequestValidationTest extends TestCase
 
 
     #[Test]
-    #[DataProvider('dataSetsThatThrowCannotProcessRequest')]
-    public function catchesCannotProcessRequest(string $path, Method $method, CannotProcessRequest $expected): void
-    {
+    #[DataProvider('dataSetsThatThrowCannotProcessSpecification')]
+    public function catchesCannotProcessSpecification(
+        string $path,
+        Method $method,
+        CannotProcessSpecification $expected
+    ): void {
         $apiProblemBuilder = self::createMock(ApiProblemBuilder::class);
         $sut = new RequestValidation(
             __DIR__ . '/../fixtures/petstore-expanded.json',

--- a/tests/Middleware/ResponseJsonNestedTest.php
+++ b/tests/Middleware/ResponseJsonNestedTest.php
@@ -7,6 +7,7 @@ namespace Membrane\Laravel\Middleware;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Http\Request;
 use Membrane\Laravel\ApiProblemBuilder;
+use Membrane\Laravel\ToSymfony;
 use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
@@ -19,9 +20,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 
-#[CoversClass('\Membrane\Laravel\Middleware\ResponseJsonNested')]
-#[UsesClass('  \Membrane\Laravel\ApiProblemBuilder')]
-#[UsesClass('  \Membrane\Laravel\ToSymfony')]
+#[CoversClass(ResponseJsonNested::class)]
+#[UsesClass(ApiProblemBuilder::class)]
+#[UsesClass(ToSymfony::class)]
 class ResponseJsonNestedTest extends TestCase
 {
     public static function dataSetsToHandle(): array


### PR DESCRIPTION
I've commented out the match case for 406. Are we checking content types in requests currently or do we never call a 406?