### PR TITLE
Ignore PHPStan complaining about missing Laravel helper methods.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,3 +2,6 @@ parameters:
 	level: 9
 	paths:
 		- src
+	ignoreErrors:
+		- '#^Function config not found.$#' # config() is a Laravel helper method
+		- '#^Function config_path not found.$#' # config_path() is a Laravel helper method


### PR DESCRIPTION
Update the PHPStan.neon file to **specifically** ignore missing `config()` and `config_path()` functions. 

Removes (now unnecessary) repetitive phpstan-ignore-next-line annotations.

Lets PHPStan check those lines for other issues. (Case and point: it then began complaining that instantiateBuilders was only returning array<object> instead of array<Builder> so I've added an array_filter to assert that).