### PR TITLE
Phpstan ignore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5.40",
-    "phpstan/phpstan": "^2.1.1",
+    "phpstan/phpstan": "^2.1.17",
     "squizlabs/php_codesniffer": "^3.7"
   },
   "extra": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,4 @@ parameters:
 	ignoreErrors:
 		- '#^Function config not found.$#' # config() is a Laravel helper method
 		- '#^Function config_path not found.$#' # config_path() is a Laravel helper method
+	reportUnmatchedIgnoredErrors: false

--- a/src/Middleware/ResponseJsonFlat.php
+++ b/src/Middleware/ResponseJsonFlat.php
@@ -24,7 +24,15 @@ class ResponseJsonFlat
     {
         $result = $this->container->get(Result::class);
 
+        /**
+         * Laravel 12 adds typehints that make this assert unnecessary
+         * Earlier versions of laravel require this assertion
+         * @TODO Remove assertion when support dropped for Laravel 11 or earlier.
+         *
+         * @phpstan-ignore-next-line
+         */
         assert($result instanceof Result);
+
         if (!$result->isValid()) {
             return $this->apiProblemBuilder->buildFromRenderer(new JsonFlat($result));
         }

--- a/src/Middleware/ResponseJsonNested.php
+++ b/src/Middleware/ResponseJsonNested.php
@@ -24,7 +24,15 @@ class ResponseJsonNested
     {
         $result = $this->container->get(Result::class);
 
+        /**
+         * Laravel 12 adds typehints that make this assert unnecessary
+         * Earlier versions of laravel require this assertion
+         * @TODO Remove assertion when support dropped for Laravel 11 or earlier.
+         *
+         * @phpstan-ignore-next-line
+         */
         assert($result instanceof Result);
+
         if (!$result->isValid()) {
             return $this->apiProblemBuilder->buildFromRenderer(new JsonNested($result));
         }


### PR DESCRIPTION
Laravel 11 or earlier do not use typehints so this assert is required.

Laravel 12 adds typehints that make the assert unnecessary.

For now a `phpstan-ignore` is added until support is dropped for all earlier versions. 