### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,20 +14,20 @@
     }
   },
   "require": {
-    "php": "^8.2.0",
-    "crell/api-problem": "^3.6.1",
-    "illuminate/console": "^9.0 || ^10.0 || ^11.0 || ^12.0",
-    "illuminate/http": "^9.0 || ^10.0 || ^11.0 || ^12.0",
-    "illuminate/support": "^9.0 || ^10.0 || ^11.0 || ^12.0",
-    "nyholm/psr7": "^1.8",
-    "membrane/membrane": "^0.9",
-    "membrane/openapi-router": "^0.5",
-    "symfony/psr-http-message-bridge": "^7.2"
+    "php": "^8.4",
+    "crell/api-problem": "^3.8.0",
+    "illuminate/console": "^13.11.2",
+    "illuminate/http": "^13.11.2",
+    "illuminate/support": "^13.11.2",
+    "nyholm/psr7": "^1.8.2",
+    "membrane/membrane": "^0.10.2",
+    "membrane/openapi-router": "^0.5.3",
+    "symfony/psr-http-message-bridge": "^8.0.8"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.5.40",
-    "phpstan/phpstan": "^2.1.17",
-    "squizlabs/php_codesniffer": "^3.7"
+    "phpunit/phpunit": "^13.1.11",
+    "phpstan/phpstan": "^2.1.55",
+    "squizlabs/php_codesniffer": "^4.0.1"
   },
   "extra": {
     "laravel": {

--- a/tests/Middleware/ResponseJsonFlatTest.php
+++ b/tests/Middleware/ResponseJsonFlatTest.php
@@ -65,7 +65,7 @@ class ResponseJsonFlatTest extends TestCase
     #[DataProvider('dataSetsToHandle')]
     public function handleTest(Result $result, SymfonyResponse $expected): void
     {
-        $request = self::createStub(Request::class);
+        $request = new Request();
         $container = self::createMock(Container::class);
         $apiProblemBuilder = new ApiProblemBuilder(400, 'about:blank', []);
         $sut = new ResponseJsonFlat($container, $apiProblemBuilder);

--- a/tests/Middleware/ResponseJsonNestedTest.php
+++ b/tests/Middleware/ResponseJsonNestedTest.php
@@ -75,7 +75,7 @@ class ResponseJsonNestedTest extends TestCase
     #[DataProvider('dataSetsToHandle')]
     public function handleTest(Result $result, SymfonyResponse $expected): void
     {
-        $request = self::createStub(Request::class);
+        $request = new Request();
         $container = self::createMock(Container::class);
         $apiProblemBuilder = new ApiProblemBuilder(400, 'about:blank', []);
         $sut = new ResponseJsonNested($container, $apiProblemBuilder);


### PR DESCRIPTION
Updated everything to latest.

PHPUnit no longer supports stubbing any class with the method `method`. So the `Request` class had to be instantiated normally.